### PR TITLE
Add package_latest option to catch up latest packages

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -9,7 +9,7 @@ class stns::client (
   $wrapper_path       = '/usr/local/bin/stns-query-wrapper',
   $chain_ssh_wrapper  = undef,
   $ssl_verify         = true,
-  $package_latest     = false,
+  $package_ensure     = present,
 
   $handle_nsswitch    = false,
   $handle_sshd_config = false,
@@ -22,6 +22,7 @@ class stns::client (
     validate_absolute_path($chain_ssh_wrapper)
   }
   validate_bool($ssl_verify)
+  validate_string($package_ensure)
   validate_bool($handle_nsswitch)
   validate_bool($handle_sshd_config)
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -9,6 +9,7 @@ class stns::client (
   $wrapper_path       = '/usr/local/bin/stns-query-wrapper',
   $chain_ssh_wrapper  = undef,
   $ssl_verify         = true,
+  $package_latest     = false,
 
   $handle_nsswitch    = false,
   $handle_sshd_config = false,

--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -3,7 +3,14 @@
 #
 # stns::client::install is to install libnss-stns and files.
 
-class stns::client::install {
+class stns::client::install(
+  $package_latest = $stns::client::package_latest,
+) {
+
+  $package_ensure = $package_latest ? {
+    true    => latest,
+    default => present,
+  }
 
   package { [
     'libnss-stns',

--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -16,7 +16,7 @@ class stns::client::install(
     'libnss-stns',
     'libpam-stns',
   ]:
-    ensure => present,
+    ensure => $package_ensure,
   }
 
 }

--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -4,13 +4,8 @@
 # stns::client::install is to install libnss-stns and files.
 
 class stns::client::install(
-  $package_latest = $stns::client::package_latest,
+  $package_ensure = $stns::client::package_ensure,
 ) {
-
-  $package_ensure = $package_latest ? {
-    true    => latest,
-    default => present,
-  }
 
   package { [
     'libnss-stns',


### PR DESCRIPTION
Using current version, if we want to always use latest packages, must write such a hack.

``` puppet
Package<| title == 'libnss-stns' |> {
  ensure => latest,
}
```

It looks unkind. So I want to handle this via class parameters.
