### PR TITLE
$package_ensure is deprecated and use $libnss_stns_ensure and $libpam_stns_ensure instead.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Release 1.5.0 (2016/07/29)
+---
+
+- Change: $package_ensure is deprecated and use $libnss_stns_ensure and $libpam_stns_ensure instead. [#22](https://github.com/STNS/puppet-stns/pull/22)
+
+
 Release 1.4.0 (2016/06/27)
 ---
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ class { '::stns::client':
   ssl_verify         => true,
   request_timeout    => 3,
   http_proxy         => 'http://proxy.example.com:1104',
-  package_ensure     => latest,
+  libnss_stns_ensure => latest,
+  libpam_stns_ensure => latest,
   handle_nsswitch    => true,
   handle_sshd_config => true,
 }
@@ -127,7 +128,8 @@ stns::client::chain_ssh_wrapper: null
 stns::client::ssl_verify: true
 stns::client::request_timeout: 3
 stns::client::http_proxy: 'http://proxy.example.com:1104'
-stns::client::package_ensure: latest
+stns::client::libnss_stns_ensure: latest
+stns::client::libpam_stns_ensure: latest
 stns::client::handle_nsswitch: true
 stns::client::handle_sshd_config: true
 ```
@@ -172,7 +174,9 @@ stns::client::handle_sshd_config: true
 - `ssl_verify`: Enables SSL verification. Valid options: a boolean. Default: true.
 - `request_timeout`: Wrapper Command Timeout. Valid options: a number. Default: 3.
 - `http_proxy`: Valid options: a string. Default: 'undef'.
-- `package_ensure`: What state the packages should be in.
+- `package_ensure`: What state the packages should be in. This parameter is deprecated and will be removed. Please use `$libnss_stns_ensure` and `$libpam_stns_ensure` instead.
+- `libnss_stns_ensure`: What state the libnss-stns package should be in.
+- `libpam_stns_ensure`: What state the libpam-stns package should be in.
 - `handle_nsswitch`: Configure nsswitch.conf to use STNS. Valid options: a boolean. Default: false.
 - `handle_sshd_config`: Configure sshd\_config to use STNS. Valid options: a boolean. Default: false.
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -11,7 +11,9 @@ class stns::client (
   $ssl_verify         = true,
   $request_timeout    = 3,
   $http_proxy         = undef,
-  $package_ensure     = present,
+  $package_ensure     = undef,
+  $libnss_stns_ensure = present,
+  $libpam_stns_ensure = present,
 
   $handle_nsswitch    = false,
   $handle_sshd_config = false,
@@ -27,6 +29,8 @@ class stns::client (
   validate_integer($request_timeout)
   validate_string($http_proxy)
   validate_string($package_ensure)
+  validate_string($libnss_stns_ensure)
+  validate_string($libpam_stns_ensure)
   validate_bool($handle_nsswitch)
   validate_bool($handle_sshd_config)
 

--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -1,17 +1,35 @@
 # Class: stns::client::install
 # ===========================
 #
-# stns::client::install is to install libnss-stns and files.
+# stns::client::install is to install libnss-stns and libpam-stns files.
 
 class stns::client::install(
-  $package_ensure = $stns::client::package_ensure,
+  $package_ensure     = $stns::client::package_ensure,
+  $libnss_stns_ensure = $stns::client::libnss_stns_ensure,
+  $libpam_stns_ensure = $stns::client::libpam_stns_ensure,
 ) {
 
-  package { [
-    'libnss-stns',
-    'libpam-stns',
-  ]:
-    ensure => $package_ensure,
+  if $package_ensure != undef {
+    warning('$package_ensure is deprecated and will be removed. Please use $libnss_stns_ensure and $libpam_stns_ensure instead.')
+  }
+
+  case $package_ensure {
+    'present', 'latest', 'absent': {
+      $_libnss_stns_ensure = $package_ensure
+      $_libpam_stns_ensure = $package_ensure
+    }
+    default: {
+      $_libnss_stns_ensure = $libnss_stns_ensure
+      $_libpam_stns_ensure = $libpam_stns_ensure
+    }
+  }
+
+  package {
+    'libnss-stns':
+      ensure => $_libnss_stns_ensure;
+
+    'libpam-stns':
+      ensure => $_libpam_stns_ensure;
   }
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "hfm-stns",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": "hfm",
   "summary": "This puppet module install and configure STNS (Simple Toml Name Service).",
   "license": "MIT",

--- a/spec/acceptance/client_spec.rb
+++ b/spec/acceptance/client_spec.rb
@@ -28,6 +28,8 @@ describe 'stns::client class' do
         ssl_verify         => true,
         request_timeout    => 3,
         http_proxy         => 'http://proxy.example.com:1104',
+        libnss_stns_ensure => latest,
+        libpam_stns_ensure => latest,
         handle_nsswitch    => true,
         handle_sshd_config => true,
       }


### PR DESCRIPTION
libnss-stns and libpam-stns don't necessarily need both. In some cases libnss-stns just enough.
