### PR TITLE
add parameter gid uid shift

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: ruby
-rvm:
-- 2.1.9
 cache: bundler
 bundler_args: "--jobs=3 --retry=3 --without=development"
-before_script: bundle exec puppet --version
-script: bundle exec rake test
-env:
-- PUPPET_VERSION='~> 3.8.0'
-- PUPPET_VERSION='~> 4.5.0'
 matrix:
   include:
+  - rvm: 2.1.9
+    env: PUPPET_VERSION='~> 3.8.0'
+    bundler_args: "--jobs=3 --retry=3 --without='development system_tests'"
+    script: bundle exec rake test
+  - rvm: 2.2.6
+    env: PUPPET_VERSION='~> 4.8.0'
+    script: bundle exec rake test
   - rvm: default
     sudo: required
     services: docker

--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ stns::client::handle_sshd_config: true
 - `ssl_verify`: Enables SSL verification. Valid options: a boolean. Default: true.
 - `request_timeout`: Wrapper Command Timeout. Valid options: a number. Default: 3.
 - `http_proxy`: Valid options: a string. Default: 'undef'.
+- `uid_shift`: Shift uid. Valid options: a number. Default: 0.
+- `gid_shift`: Shift gid. Valid options: a number. Default: 0.
 - `package_ensure`: What state the packages should be in. This parameter is deprecated and will be removed. Please use `$libnss_stns_ensure` and `$libpam_stns_ensure` instead.
 - `libnss_stns_ensure`: What state the libnss-stns package should be in.
 - `libpam_stns_ensure`: What state the libpam-stns package should be in.

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -12,6 +12,8 @@ class stns::client (
   $request_timeout    = 3,
   $http_proxy         = undef,
   $request_header     = undef,
+  $uid_shift          = 0,
+  $gid_shift          = 0,
 
   $package_ensure     = undef,
   $libnss_stns_ensure = present,

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -32,6 +32,8 @@ class stns::client (
   validate_bool($ssl_verify)
   validate_integer($request_timeout)
   validate_string($http_proxy)
+  validate_integer($uid_shift)
+  validate_integer($gid_shift)
   validate_string($package_ensure)
   validate_string($libnss_stns_ensure)
   validate_string($libpam_stns_ensure)

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -13,6 +13,8 @@ class stns::client::config (
   $request_timeout   = $stns::client::request_timeout,
   $http_proxy        = $stns::client::http_proxy,
   $request_header    = $stns::client::request_header,
+  $uid_shift         = $stns::client::uid_shift,
+  $gid_shift         = $stns::client::gid_shift,
 ){
 
   if $request_header != undef {

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -8,8 +8,6 @@ class stns::server::config {
   $port     = $stns::server::port
   $user     = $stns::server::user
   $password = $stns::server::password
-  $users    = $stns::server::users
-  $groups   = $stns::server::groups
 
   concat { '/etc/stns/stns.conf':
     ensure => present,

--- a/spec/acceptance/client_spec.rb
+++ b/spec/acceptance/client_spec.rb
@@ -29,6 +29,8 @@ describe 'stns::client class' do
         ssl_verify         => true,
         request_timeout    => 3,
         http_proxy         => 'http://proxy.example.com:1104',
+        uid_shift          => 0,
+        gid_shift          => 0,
         request_header     => {
           'x-api-key1' => 'foo',
           'x-api-key2' => 'bar',
@@ -75,6 +77,8 @@ describe 'stns::client class' do
       expect(conf['ssl_verify']).to eq true
       expect(conf['request_timeout']).to eq 3
       expect(conf['http_proxy']).to eq 'http://proxy.example.com:1104'
+      expect(conf['uid_shift']).to eq 0
+      expect(conf['gid_shift']).to eq 0
       expect(conf['request_header']['x-api-key1']).to eq 'foo'
       expect(conf['request_header']['x-api-key2']).to eq 'bar'
     end

--- a/templates/libnss_stns.conf.erb
+++ b/templates/libnss_stns.conf.erb
@@ -20,6 +20,10 @@ ssl_verify = <%= @ssl_verify %>
 request_timeout = <%= @request_timeout %>
 
 http_proxy = "<%= @http_proxy %>"
+
+# The shift of uid and gid is available after version3 API
+uid_shift = <%= @uid_shift %>
+gid_shift = <%= @gid_shift %>
 <% if @request_header -%>
 
 [request_header]


### PR DESCRIPTION
Hi!
A parameter that can shift the uid and gid on the client side has been added.[libnss-stns #45](https://github.com/STNS/libnss_stns/pull/45)
Since it can be used in API version 3 or later.