### PR TITLE
Fix ordering about APT repository (resolves #16)

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -18,14 +18,10 @@ class stns::repo {
       }
     }
     'Debian': {
-      apt::source { 'stns':
-        location => 'http://repo.stns.jp/debian/',
-        release  => 'stns',
-        key      => {
-          id     => '6BACCE33697C7E568D5C162F018A7A21B2EC51BA',
-          source => $gpgkey_url,
-        }
-      }
+      include ::apt
+      require ::apt::update
+
+      include stns::repo::apt
     }
     default: {
       fail("Unsupported osfamily: ${::osfamily}")

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -1,0 +1,10 @@
+class stns::repo::apt {
+  apt::source { 'stns':
+    location => 'http://repo.stns.jp/debian/',
+    release  => 'stns',
+    key      => {
+      id     => '6BACCE33697C7E568D5C162F018A7A21B2EC51BA',
+      source => $::stns::repo::gpgkey_url,
+    }
+  }
+}


### PR DESCRIPTION
On Debian/Ubuntu, the ordering
```
::Apt::Source['stns'] ~>
Class['::Apt::Update'] ->
Class['::Stns::Client::Install', '::Stns::Server::Install']
```
must hold to install packages from an APT repository managed by Puppet.

This patch extracts APT-related part from `::stns::repo` class in order to make `::stns::repo` require `::apt::update` while avoiding dependency cycles: `::stns::repo` cannot both contain an `::apt::source` and require `::apt::update` since `::apt::source` notifies `::apt::update`.