### PR TITLE
fixed stns.conf parameter name

### DIFF
--- a/spec/acceptance/client_spec.rb
+++ b/spec/acceptance/client_spec.rb
@@ -56,7 +56,7 @@ describe 'stns::client class' do
     its(:content) { is_expected.to match %r{^user = "sample"$} }
     its(:content) { is_expected.to match %r{^password = "s@mp1e"$} }
     its(:content) { is_expected.to match %r{^chain_ssh_wrapper = "/usr/libexec/openssh/ssh-ldap-wrapper"$} }
-    its(:content) { is_expected.to match %r{^query_wrapper = "/usr/local/bin/stns-query-wrapper"$} }
+    its(:content) { is_expected.to match %r{^wrapper_path = "/usr/local/bin/stns-query-wrapper"$} }
     its(:content) { is_expected.to match %r{^ssl_verify = true$} }
     its(:content) { is_expected.to match %r{^http_proxy = "http://proxy.example.com:1104"$} }
     its(:content) { is_expected.to match %r{^uid_shift = 0$} }

--- a/templates/client/stns.conf.erb
+++ b/templates/client/stns.conf.erb
@@ -15,7 +15,7 @@ password = "<%= @password %>"
 chain_ssh_wrapper = "<%= @chain_ssh_wrapper %>"
 <%- end -%>
 <%- if @wrapper_path -%>
-query_wrapper = "<%= @wrapper_path %>"
+wrapper_path = "<%= @wrapper_path %>"
 <%- end -%>
 <%- if @ssl_verify -%>
 ssl_verify = <%= @ssl_verify %>


### PR DESCRIPTION
Authentication fails when using http_proxy and query_wrapper.

