### PR TITLE
update to gpg key id for apt repo.

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -3,7 +3,7 @@ class stns::repo::apt {
     location => 'http://repo.stns.jp/debian/',
     release  => 'stns',
     key      => {
-      id     => '6BACCE33697C7E568D5C162F018A7A21B2EC51BA',
+      id     => 'ED9008B740C6735CB3EF098C37DE344F75E258B6',
       source => $::stns::repo::gpgkey_url,
     }
   }


### PR DESCRIPTION
I will resolve the cause of the error below.

```txt
Error: Could not set 'present' on ensure: The id in your manifest 6BACCE33697C7E568D5C162F018A7A21B2EC51BA and the fingerprint from content/source don't match. Check for an error in the id and content/source is legitimate. (file: /etc/puppetlabs/code/vendor/modules/apt/manifests/key.pp, line: 33)
```

Changed to the string output by `gpg --list-packets GPG-KEY-stns`.

```sh
$ curl -Ss https://repo.stns.jp/gpg/GPG-KEY-stns -O
$ gpg --list-packets ./GPG-KEY-stns
# off=0 ctb=99 tag=6 hlen=3 plen=525
:public key packet:
        version 4, algo 1, created 1686968525, expires 0
        pkey[0]: [4096 bits]
        pkey[1]: [17 bits]
        keyid: 37DE344F75E258B6
# off=528 ctb=b4 tag=13 hlen=2 plen=36
:user ID packet: "stns-server <www.kazu.com@gmail.com>"
# off=566 ctb=89 tag=2 hlen=3 plen=593
:signature packet: algo 1, keyid 37DE344F75E258B6
        version 4, created 1686968554, md5len 0, sigclass 0x13
        digest algo 8, begin of digest bd 32
        hashed subpkt 27 len 1 (key flags: 03)
        hashed subpkt 11 len 4 (pref-sym-algos: 9 8 7 2)
        hashed subpkt 34 len 1 (pref-aead-algos: 2)
        hashed subpkt 21 len 5 (pref-hash-algos: 10 9 8 11 2)
        hashed subpkt 22 len 3 (pref-zip-algos: 2 3 1)
        hashed subpkt 30 len 1 (features: 07)
        hashed subpkt 23 len 1 (keyserver preferences: 80)
        hashed subpkt 33 len 21 (issuer fpr v4 ED9008B740C6735CB3EF098C37DE344F75E258B6) 👈
        hashed subpkt 2 len 4 (sig created 2023-06-17)
        subpkt 16 len 8 (issuer key ID 37DE344F75E258B6)
        data: [4095 bits]
```