### PR TITLE
setup apt source location.

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -1,7 +1,9 @@
 class stns::repo::apt {
+  $dist = $::facts['lsbdistcodename']
   apt::source { 'stns':
-    location => 'http://repo.stns.jp/debian/',
+    location => "http://repo.stns.jp/${dist}/",
     release  => 'stns',
+    repos    => $dist,
     key      => {
       id     => 'ED9008B740C6735CB3EF098C37DE344F75E258B6',
       source => $::stns::repo::gpgkey_url,


### PR DESCRIPTION
Hi @pyama86 

Fixed the setting of the stns apt repository.
ref. https://github.com/STNS/package/blob/master/assets/scripts/apt-repo.sh#L14-L15

The following is the content of the file when applied to Jammy and Focal.

### jammy

```sh
root@fdc354e081a4:/# cat /etc/apt/sources.list.d/stns.list
# This file is managed by Puppet. DO NOT EDIT.
# stns
deb http://repo.stns.jp/jammy/ stns jammy
```

### focal

```sh
root@bb63427151f3:/# cat /etc/apt/sources.list.d/stns.list
# This file is managed by Puppet. DO NOT EDIT.
# stns
deb http://repo.stns.jp/focal/ stns focal
```