### PR TITLE
Fix Issue of empty output when stns::client::http_keepalive is set to undef

### DIFF
--- a/templates/client/stns.conf.erb
+++ b/templates/client/stns.conf.erb
@@ -23,7 +23,7 @@ ssl_verify = <%= @ssl_verify %>
 <%- if @http_proxy -%>
 http_proxy = "<%= @http_proxy %>"
 <%- end -%>
-<%- if ! @http_keepalive -%>
+<%- if @http_keepalive || @http_keepalive == false -%>
 http_keepalive = <%= @http_keepalive %>
 <%- end -%>
 <%- if @uid_shift -%>


### PR DESCRIPTION
ref: #50 
stns::client::http_keepaliveがundefの場合に、stns.confに空の値が出力されてしまいます。
空の場合パーサによってはSyntax Errorになってしまうため、true/falseの場合のみ該当の項目を出力するように変更します。

```
      # ./vendor/bundle/ruby/3.2.0/gems/toml-rb-2.2.0/lib/toml-rb/parser.rb:16:in `rescue in initialize'
     # ./vendor/bundle/ruby/3.2.0/gems/toml-rb-2.2.0/lib/toml-rb/parser.rb:12:in `initialize'
     # ./vendor/bundle/ruby/3.2.0/gems/toml-rb-2.2.0/lib/toml-rb.rb:47:in `new'
     # ./vendor/bundle/ruby/3.2.0/gems/toml-rb-2.2.0/lib/toml-rb.rb:47:in `parse'
     # ./spec/base/stns_spec.rb:12:in `block (3 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Citrus::ParseError:
     #   Failed to parse input on line 6 at offset 17
     #   http_keepalive = 
     #   
     #                    ^
     #   ./vendor/bundle/ruby/3.2.0/gems/citrus-3.0.2/lib/citrus.rb:669:in `parse'
```